### PR TITLE
made signature/deliveryId header fields lowercase

### DIFF
--- a/src/hubot-github-webhook-listener.coffee
+++ b/src/hubot-github-webhook-listener.coffee
@@ -52,8 +52,8 @@ module.exports = (robot) ->
         robot.logger.info("Github post received: ", req)
       eventBody =
         eventType   : req.headers["x-github-event"]
-        signature   : req.headers["X-Hub-Signature"]
-        deliveryId  : req.headers["X-Github-Delivery"]
+        signature   : req.headers["x-hub-signature"]
+        deliveryId  : req.headers["x-github-delivery"]
         payload     : req.body
         query       : querystring.parse(url.parse(req.url).query)
 


### PR DESCRIPTION
Hubot doesn't seem to understand the case sensitive "X-Hub-Signature" or "X-Github-Delivery" header fields when listening to webhook events. Making them lowercase fixes this issue, of which you can then proceed to validate the sha1 hash to ensure that the event is coming from github.
